### PR TITLE
[feat] add new dashboard modal

### DIFF
--- a/src/app/(with-header-sidebar)/layout.module.css
+++ b/src/app/(with-header-sidebar)/layout.module.css
@@ -9,4 +9,6 @@
 
 .mainWrapper {
   flex: 1;
+  display: flex;
+  flex-direction: column;
 }

--- a/src/app/(with-header-sidebar)/mydashboard/_components/Input.module.css
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/Input.module.css
@@ -1,0 +1,59 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.label {
+  font-size: 16px;
+  font-weight: 400;
+  color: var(--black-100);
+}
+
+.inputWrapper {
+  position: relative;
+}
+
+.input {
+  width: 100%;
+  border: 1px solid var(--gray-300);
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--black-100);
+  padding: 12px 16px;
+}
+
+.input:read-only {
+  color: var(--gray-400);
+  outline: none;
+}
+
+.input:focus:not(:read-only) {
+  outline-color: var(--violet);
+}
+
+.input::placeholder {
+  color: var(--gray-400);
+}
+
+.errorFocus {
+  outline: 1px solid var(--red);
+}
+
+.error {
+  display: block;
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--red);
+}
+
+@media screen and (min-width: 768px) {
+  .label {
+    font-size: 18px;
+  }
+
+  .input {
+    font-size: 16px;
+  }
+}

--- a/src/app/(with-header-sidebar)/mydashboard/_components/Input.tsx
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/Input.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { FieldError, UseFormRegisterReturn } from 'react-hook-form';
+import styles from './Input.module.css';
+
+interface InputProps {
+  type?: string;
+  name: string;
+  labelClassName?: string;
+  inputClassName?: string;
+  errorClassName?: string;
+  label?: string;
+  placeholder?: string;
+  children?: ReactNode;
+  register?: UseFormRegisterReturn;
+  error?: FieldError;
+  readOnly?: boolean;
+}
+
+export default function Input({
+  type = 'text',
+  name,
+  labelClassName = '',
+  inputClassName = '',
+  errorClassName = '',
+  label = '',
+  placeholder = '',
+  children,
+  register,
+  error,
+  readOnly = false,
+}: InputProps) {
+  return (
+    <div className={`${styles.container}`}>
+      <label className={`${styles.label} ${labelClassName}`} htmlFor={name}>
+        {label}
+      </label>
+      <div className={styles.inputWrapper}>
+        <input
+          className={`${styles.input} ${inputClassName} ${error ? styles.errorFocus : ''}`}
+          type={type}
+          placeholder={placeholder}
+          readOnly={readOnly}
+          {...register}
+        />
+        {children}
+      </div>
+      {error && (
+        <span className={`${styles.error} ${errorClassName}`}>
+          {error.message}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/app/(with-header-sidebar)/mydashboard/_components/dashboards/AddDashboardCard.module.css
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/dashboards/AddDashboardCard.module.css
@@ -1,0 +1,25 @@
+.addDashboard.addDashboard {
+  background: var(--white);
+  color: var(--black-100);
+  font-size: 14px;
+  font-weight: 600;
+  padding: 15px 20px;
+  background: var(--white);
+  border: 1px solid var(--gray-300);
+  border-radius: 8px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  transition: background-color 0.3s ease;
+}
+
+.addDashboard.addDashboard:hover {
+  background-color: var(--violet-light);
+}
+
+@media screen and (min-width: 768px) {
+  .addDashboard.addDashboard {
+    font-size: 16px;
+  }
+}

--- a/src/app/(with-header-sidebar)/mydashboard/_components/dashboards/AddDashboardCard.tsx
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/dashboards/AddDashboardCard.tsx
@@ -1,19 +1,35 @@
 import Button from '@/components/Button';
 import Image from 'next/image';
 import styles from './AddDashboardCard.module.css';
+import { useModal } from '../../_hooks/useModal';
+import Modal from '../modal/Modal';
 
 export default function AddDashboardCard() {
+  const { isOpen, openModal, isClosing, closeModal } = useModal();
+
   return (
-    <Button className={styles.addDashboard}>
-      <span>새로운 대시보드</span>
-      <span className={styles.addIconWrapper}>
-        <Image
-          src="/icons/add.svg"
-          alt="새로운 대시보드 추가"
-          width={16}
-          height={16}
-        />
-      </span>
-    </Button>
+    <div>
+      <Button className={styles.addDashboard} onClick={openModal}>
+        <span>새로운 대시보드</span>
+        <span className={styles.addIconWrapper}>
+          <Image
+            src="/icons/add.svg"
+            alt="새로운 대시보드 추가"
+            width={16}
+            height={16}
+          />
+        </span>
+      </Button>
+      {isOpen && (
+        <Modal
+          isClosing={isClosing}
+          onClose={closeModal}
+          title="새로운 대시보드"
+        >
+          <p>hi</p>
+          <div>hi2</div>
+        </Modal>
+      )}
+    </div>
   );
 }

--- a/src/app/(with-header-sidebar)/mydashboard/_components/dashboards/AddDashboardCard.tsx
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/dashboards/AddDashboardCard.tsx
@@ -1,0 +1,19 @@
+import Button from '@/components/Button';
+import Image from 'next/image';
+import styles from './AddDashboardCard.module.css';
+
+export default function AddDashboardCard() {
+  return (
+    <Button className={styles.addDashboard}>
+      <span>새로운 대시보드</span>
+      <span className={styles.addIconWrapper}>
+        <Image
+          src="/icons/add.svg"
+          alt="새로운 대시보드 추가"
+          width={16}
+          height={16}
+        />
+      </span>
+    </Button>
+  );
+}

--- a/src/app/(with-header-sidebar)/mydashboard/_components/dashboards/AddDashboardCard.tsx
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/dashboards/AddDashboardCard.tsx
@@ -3,6 +3,9 @@ import Image from 'next/image';
 import styles from './AddDashboardCard.module.css';
 import { useModal } from '../../_hooks/useModal';
 import Modal from '../modal/Modal';
+import AddDashboardContent from './AddDashboardForm';
+
+const TITLE = '새로운 대시보드';
 
 export default function AddDashboardCard() {
   const { isOpen, openModal, isClosing, closeModal } = useModal();
@@ -10,24 +13,14 @@ export default function AddDashboardCard() {
   return (
     <div>
       <Button className={styles.addDashboard} onClick={openModal}>
-        <span>새로운 대시보드</span>
+        <span>{TITLE}</span>
         <span className={styles.addIconWrapper}>
-          <Image
-            src="/icons/add.svg"
-            alt="새로운 대시보드 추가"
-            width={16}
-            height={16}
-          />
+          <Image src="/icons/add.svg" alt={TITLE} width={16} height={16} />
         </span>
       </Button>
       {isOpen && (
-        <Modal
-          isClosing={isClosing}
-          onClose={closeModal}
-          title="새로운 대시보드"
-        >
-          <p>hi</p>
-          <div>hi2</div>
+        <Modal isClosing={isClosing} onClose={closeModal} title={TITLE}>
+          <AddDashboardContent />
         </Modal>
       )}
     </div>

--- a/src/app/(with-header-sidebar)/mydashboard/_components/dashboards/AddDashboardForm.module.css
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/dashboards/AddDashboardForm.module.css
@@ -1,0 +1,3 @@
+.form {
+  margin-top: 24px;
+}

--- a/src/app/(with-header-sidebar)/mydashboard/_components/dashboards/AddDashboardForm.tsx
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/dashboards/AddDashboardForm.tsx
@@ -1,0 +1,43 @@
+import { useForm } from 'react-hook-form';
+import Button from '@/components/Button';
+import { ERROR_MESSAGES } from '../../_constants/message';
+import styles from './AddDashboardForm.module.css';
+import Input from '../Input';
+
+interface AddDashboardFormValue {
+  title: string;
+  color: string;
+}
+
+export default function AddDashboardForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<AddDashboardFormValue>({ mode: 'onChange' });
+
+  const onSubmit = () => {
+    // TODO
+    console.log('AddDashboardContent');
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
+      <Input
+        name="title"
+        label="대시보드 이름"
+        placeholder="새로운 프로젝트"
+        register={register('title', {
+          required: ERROR_MESSAGES.DASHBOARD_TITLE_REQUIRE,
+        })}
+        error={errors.title}
+      />
+      <div>
+        <Button>취소</Button>
+        <Button type="submit" disabled={!isValid}>
+          생성
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(with-header-sidebar)/mydashboard/_components/dashboards/Dashboards.module.css
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/dashboards/Dashboards.module.css
@@ -5,26 +5,6 @@
   gap: 8px;
 }
 
-.addDashboard.addDashboard {
-  background: var(--white);
-  color: var(--black-100);
-  font-size: 14px;
-  font-weight: 600;
-  padding: 15px 20px;
-  background: var(--white);
-  border: 1px solid var(--gray-300);
-  border-radius: 8px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 12px;
-  transition: background-color 0.3s ease;
-}
-
-.addDashboard.addDashboard:hover {
-  background-color: var(--violet-light);
-}
-
 .addIconWrapper {
   border-radius: 4px;
   background: var(--violet-light);
@@ -38,9 +18,5 @@
     grid-template-rows: repeat(3, 1fr);
     grid-template-columns: repeat(2, 1fr);
     gap: 10px;
-  }
-
-  .addDashboard.addDashboard {
-    font-size: 16px;
   }
 }

--- a/src/app/(with-header-sidebar)/mydashboard/_components/dashboards/Dashboards.tsx
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/dashboards/Dashboards.tsx
@@ -3,9 +3,8 @@
 import useDashboards from '../../_hooks/useDashboards';
 import Pagination from './Pagination';
 import DashboardCard from './DashboardCard';
-import Button from '@/components/Button';
-import Image from 'next/image';
 import styles from './Dashboards.module.css';
+import AddDashboardCard from './AddDashboardCard';
 
 const PAGE_SIZE = 5;
 
@@ -17,17 +16,7 @@ export default function Dashboards() {
   return (
     <div>
       <section className={styles.dashboardsWrapper}>
-        <Button className={styles.addDashboard}>
-          <span>새로운 대시보드</span>
-          <span className={styles.addIconWrapper}>
-            <Image
-              src="/icons/add.svg"
-              alt="새로운 대시보드 추가"
-              width={16}
-              height={16}
-            />
-          </span>
-        </Button>
+        <AddDashboardCard />
         {dashboards.map((board) => (
           <DashboardCard key={board.id} {...board} />
         ))}

--- a/src/app/(with-header-sidebar)/mydashboard/_components/invitations/Invitations.module.css
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/invitations/Invitations.module.css
@@ -1,9 +1,11 @@
 .invitations {
   background-color: var(--white);
   border-radius: 8px;
-  min-height: 260px;
-  margin-top: 16px;
   padding: 24px 20px 80px 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  gap: 30px;
 }
 
 .title {
@@ -14,7 +16,6 @@
 
 .descriptionWrapper {
   text-align: center;
-  margin-top: 60px;
 }
 
 .description {
@@ -25,18 +26,13 @@
 
 @media screen and (min-width: 768px) {
   .invitations {
-    margin-top: 40px;
+    padding: 24px 40px 120px 40px;
+    gap: 60px;
   }
 
   .title {
     font-size: 24px;
   }
-
-  .descriptionWrapper {
-    text-align: center;
-    margin-top: 64px;
-  }
-
   .description {
     font-size: 18px;
   }

--- a/src/app/(with-header-sidebar)/mydashboard/_components/modal/FocusTrap.tsx
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/modal/FocusTrap.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useRef, ReactNode } from 'react';
+
+interface FocusTrapProps {
+  children: ReactNode;
+}
+
+export default function FocusTrap({ children }: FocusTrapProps) {
+  const startRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const focusableElements = startRef.current?.querySelectorAll(
+      'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    ) as NodeListOf<HTMLElement>;
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    const trapFocus = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+
+      if (e.shiftKey) {
+        // Shift + Tab
+        if (document.activeElement === firstElement) {
+          e.preventDefault();
+          lastElement.focus();
+        }
+      } else {
+        // Tab
+        if (document.activeElement === lastElement) {
+          e.preventDefault();
+          firstElement.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', trapFocus);
+
+    firstElement?.focus();
+
+    return () => {
+      document.removeEventListener('keydown', trapFocus);
+    };
+  }, []);
+
+  return <div ref={startRef}>{children}</div>;
+}

--- a/src/app/(with-header-sidebar)/mydashboard/_components/modal/FocusTrap.tsx
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/modal/FocusTrap.tsx
@@ -42,5 +42,9 @@ export default function FocusTrap({ children }: FocusTrapProps) {
     };
   }, []);
 
-  return <div ref={startRef}>{children}</div>;
+  return (
+    <div ref={startRef} style={{ width: '100%' }}>
+      {children}
+    </div>
+  );
 }

--- a/src/app/(with-header-sidebar)/mydashboard/_components/modal/Modal.module.css
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/modal/Modal.module.css
@@ -37,9 +37,10 @@
 }
 
 .title {
-  font-size: 18px;
-  font-weight: 600;
+  font-size: 20px;
+  font-weight: 700;
   flex: 1;
+  color: var(--black-100);
 }
 
 .close {
@@ -93,8 +94,11 @@
   }
 }
 
-@media (max-width: 767px) {
-  .container {
-    max-width: 340px;
+@media screen and (min-width: 768px) {
+  .title {
+    font-size: 24px;
+    font-weight: 700;
+    flex: 1;
+    color: var(--black-100);
   }
 }

--- a/src/app/(with-header-sidebar)/mydashboard/_components/modal/Modal.module.css
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/modal/Modal.module.css
@@ -14,13 +14,14 @@
 }
 
 .container {
+  min-width: 330px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   border-radius: 8px;
   background: var(--gray-100);
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
-  padding: 24px 16px 32px 16px;
+  padding: 20px 16px;
   transform: translateY(-50px);
   animation: slideIn 0.5s ease forwards;
 }
@@ -95,6 +96,10 @@
 }
 
 @media screen and (min-width: 768px) {
+  .container {
+    min-width: 580px;
+  }
+
   .title {
     font-size: 24px;
     font-weight: 700;

--- a/src/app/(with-header-sidebar)/mydashboard/_components/modal/Modal.module.css
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/modal/Modal.module.css
@@ -1,0 +1,100 @@
+.background {
+  z-index: 999;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  animation: fadeIn 0.5s ease forwards;
+}
+
+.background.fadeOut {
+  animation: fadeOut 0.5s ease forwards;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  border-radius: 8px;
+  background: var(--gray-100);
+  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+  padding: 24px 16px 32px 16px;
+  transform: translateY(-50px);
+  animation: slideIn 0.5s ease forwards;
+}
+
+.container.slideOut {
+  animation: slideOut 0.5s ease forwards;
+}
+
+.titleContainer {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.title {
+  font-size: 18px;
+  font-weight: 600;
+  flex: 1;
+}
+
+.close {
+  width: 24px;
+  height: 24px;
+  transition: 200ms;
+}
+
+.close:hover {
+  filter: brightness(2);
+  transform: rotate(90deg);
+}
+
+@keyframes fadeIn {
+  from {
+    background-color: rgba(0, 0, 0, 0);
+  }
+  to {
+    background-color: rgba(0, 0, 0, 0.8);
+  }
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateY(-50px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes fadeOut {
+  from {
+    background-color: rgba(0, 0, 0, 0.8);
+  }
+  to {
+    background-color: rgba(0, 0, 0, 0);
+  }
+}
+
+@keyframes slideOut {
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(-50px);
+    opacity: 0;
+  }
+}
+
+@media (max-width: 767px) {
+  .container {
+    max-width: 340px;
+  }
+}

--- a/src/app/(with-header-sidebar)/mydashboard/_components/modal/Modal.tsx
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/modal/Modal.tsx
@@ -53,7 +53,7 @@ export default function Modal({
         <FocusTrap>
           <div className={styles.titleContainer}>
             {title && <h3 className={styles.title}>{title}</h3>}
-            <button
+            {/* <button
               onClick={onClose}
               className={styles.close}
               aria-label="Close modal"
@@ -64,7 +64,7 @@ export default function Modal({
                 width={10}
                 height={10}
               />
-            </button>
+            </button> */}
           </div>
           {children}
         </FocusTrap>

--- a/src/app/(with-header-sidebar)/mydashboard/_components/modal/Modal.tsx
+++ b/src/app/(with-header-sidebar)/mydashboard/_components/modal/Modal.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { createPortal } from 'react-dom';
+import { ReactNode, useEffect, MouseEvent } from 'react';
+import FocusTrap from './FocusTrap';
+import Image from 'next/image';
+import styles from './Modal.module.css';
+
+interface ModalProps {
+  isClosing: boolean;
+  onClose: () => void;
+  allowDimClose?: boolean;
+  title?: string;
+  children: ReactNode;
+}
+
+export default function Modal({
+  isClosing,
+  onClose,
+  allowDimClose = true,
+  title,
+  children,
+}: ModalProps) {
+  const handleOnClickBackground = (e: MouseEvent<HTMLDivElement>) => {
+    if (!allowDimClose || !(e.target === e.currentTarget)) {
+      return;
+    }
+    onClose();
+  };
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      className={`${styles.background} ${isClosing ? styles.fadeOut : ''}`}
+      onClick={handleOnClickBackground}
+    >
+      <div
+        className={`${styles.container} ${isClosing ? styles.slideOut : ''}`}
+      >
+        <FocusTrap>
+          <div className={styles.titleContainer}>
+            {title && <h3 className={styles.title}>{title}</h3>}
+            <button
+              onClick={onClose}
+              className={styles.close}
+              aria-label="Close modal"
+            >
+              <Image
+                src="/icons/x_sm.svg"
+                alt="Close icon"
+                width={10}
+                height={10}
+              />
+            </button>
+          </div>
+          {children}
+        </FocusTrap>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/app/(with-header-sidebar)/mydashboard/_constants/message.ts
+++ b/src/app/(with-header-sidebar)/mydashboard/_constants/message.ts
@@ -1,0 +1,3 @@
+export const ERROR_MESSAGES = {
+  DASHBOARD_TITLE_REQUIRE: '대시보드 이름은 필수입니다.',
+};

--- a/src/app/(with-header-sidebar)/mydashboard/_hooks/useModal.ts
+++ b/src/app/(with-header-sidebar)/mydashboard/_hooks/useModal.ts
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+
+export function useModal() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
+
+  const openModal = () => {
+    setIsOpen(true);
+    document.body.style.overflow = 'hidden';
+  };
+
+  const closeModal = (onClose = () => {}) => {
+    setIsClosing(true);
+    setTimeout(() => {
+      document.body.style.overflow = 'unset';
+      setIsOpen(false);
+      onClose();
+      setIsClosing(false);
+    }, 300);
+  };
+
+  return {
+    isOpen,
+    openModal,
+    isClosing,
+    closeModal,
+  };
+}

--- a/src/app/(with-header-sidebar)/mydashboard/page.module.css
+++ b/src/app/(with-header-sidebar)/mydashboard/page.module.css
@@ -2,4 +2,8 @@
   height: 100%;
   background: var(--gray-100);
   padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  overflow-y: scroll;
 }

--- a/src/components/MainContainer.module.css
+++ b/src/components/MainContainer.module.css
@@ -1,3 +1,4 @@
-.main {
-  height: 100%;
+.mainContainer {
+  flex: 1 1 auto;
+  overflow-y: auto;
 }

--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -6,7 +6,7 @@ export default function MainContainer({ children }: { children: ReactNode }) {
   return (
     <>
       <Header />
-      <main className={styles.main}>{children}</main>
+      <main className={styles.mainContainer}>{children}</main>
     </>
   );
 }

--- a/src/components/header/Header.module.css
+++ b/src/components/header/Header.module.css
@@ -5,6 +5,7 @@
   justify-content: space-around;
   align-items: center;
   gap: 16px;
+  flex: 0 0 auto;
 }
 
 .title {

--- a/src/components/header/Header.module.css
+++ b/src/components/header/Header.module.css
@@ -11,7 +11,7 @@
 .title {
   flex: 1;
   color: var(--black-100);
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 700;
 }
 

--- a/src/components/sidebar/SideBar.module.css
+++ b/src/components/sidebar/SideBar.module.css
@@ -2,7 +2,9 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 15px;
+  gap: 12px;
+  height: 100%;
+  overflow-y: auto;
 }
 
 .logo.logo {


### PR DESCRIPTION
## 📌 Related Issue

> close #25 

## 📝 Description

- 헤더 고정, 헤더밑에 내용물 스크롤
- 사이드바 스크롤
- 새로운 대시보드 추가 모달
- 새로운 대시보드 input 추가

## 📸 Screenshot
<img width="370" alt="image" src="https://github.com/user-attachments/assets/0704ee79-1914-4f24-b986-011d326c8251">
<img width="1192" alt="image" src="https://github.com/user-attachments/assets/8b0b2af8-4f04-4145-8d57-9f80e2e7f83c">


## 📢 Notes

- input은 첨에 지원님이 만드신거 가져다 쓰려고했는데 약간의 커스텀이 필요해서 거의 복붙?수준으로 살짝 가져다 썼습니다..🙏
- 조금 더  커스텀하게 가져다쓸수있는 input 만들면 공통으로 사용해봐도 좋고, 아님 이번엔 그냥 이렇게 가는것도 갠찮습니다~
- 모달은 저번 프로젝트꺼 복붙수준이에요
- 모달 내용 아직 미완성입니다ㅠ