### PR TITLE
[feat] add invitation modal and cancel invitation

### DIFF
--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/EmptyInvitations.module.css
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/EmptyInvitations.module.css
@@ -1,0 +1,32 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  padding: 80px 0;
+}
+
+.description {
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 18px;
+  color: var(--gray-400);
+}
+
+@media screen and (min-width: 768px) {
+  .container {
+    gap: 24px;
+    padding-bottom: 120px;
+  }
+
+  .container img {
+    width: 100px;
+    height: 100px;
+  }
+
+  .description {
+    font-size: 18px;
+    line-height: 26px;
+  }
+}

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/EmptyInvitations.tsx
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/EmptyInvitations.tsx
@@ -1,0 +1,16 @@
+import Image from 'next/image';
+import styles from './EmptyInvitations.module.css';
+
+export default function EmptyInvitations() {
+  return (
+    <div className={styles.container}>
+      <Image
+        src="/images/unsubscribe.svg"
+        width={60}
+        height={60}
+        alt="비어있는 초대 내역"
+      />
+      <p className={styles.description}>아직 초대된 사람이 없어요</p>
+    </div>
+  );
+}

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/InvitationModal.module.css
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/InvitationModal.module.css
@@ -1,0 +1,88 @@
+.modal {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px 16px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.header h2 {
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 32px;
+  color: var(--black-100);
+}
+
+.xButton.xButton {
+  width: auto;
+  background-color: transparent;
+}
+
+.input input {
+  width: 295px;
+  font-size: 14px;
+  line-height: 24px;
+  padding: 13px 16px;
+}
+
+.input label {
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 26px;
+}
+
+.footer {
+  display: flex;
+  gap: 7px;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 26px;
+  margin-top: 8px;
+}
+
+.footer button {
+  padding: 14px 0;
+}
+
+.cancel.cancel {
+  border: 1px solid var(--gray-300);
+  background-color: var(--white);
+  color: var(--gray-500);
+}
+
+@media screen and (min-width: 768px) {
+  .modal {
+    gap: 24px;
+    padding: 24px;
+  }
+
+  .header h2 {
+    font-size: 24px;
+  }
+
+  .xButton img {
+    width: 36px;
+    height: 36px;
+  }
+
+  .input label {
+    font-size: 18px;
+  }
+
+  .input input {
+    width: 520px;
+    font-size: 16px;
+    line-height: 26px;
+    padding: 12px 16px;
+  }
+
+  .footer {
+    gap: 8px;
+    margin-top: 0;
+  }
+}

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/InvitationModal.tsx
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/InvitationModal.tsx
@@ -1,0 +1,54 @@
+import Image from 'next/image';
+import { useForm } from 'react-hook-form';
+import Button from '@/components/Button';
+import useModalStore from '@/store/modalStore';
+import Input from '@/components/Input';
+import styles from './InvitationModal.module.css';
+import { ERROR_MESSAGES } from '@/constants/message';
+
+export default function InvitationModal({
+  handleInvite,
+}: {
+  handleInvite: (email: string) => void;
+}) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<{ email: string }>({ mode: 'onChange' });
+  const { closeModal } = useModalStore();
+
+  const onSubmit = async ({ email }: { email: string }) => {
+    handleInvite(email);
+    closeModal();
+  };
+
+  return (
+    <form className={styles.modal} onSubmit={handleSubmit(onSubmit)}>
+      <div className={styles.header}>
+        <h2>초대하기</h2>
+        <Button onClick={closeModal} className={styles.xButton}>
+          <Image src="/icons/x_sm.svg" alt="모달 종료" width={24} height={24} />
+        </Button>
+      </div>
+      <Input
+        className={styles.input}
+        label="이메일"
+        name="email"
+        placeholder="이메일 입력"
+        register={register('email', {
+          required: ERROR_MESSAGES.EMAIL_REQUIRE,
+        })}
+        error={errors.email}
+      />
+      <div className={styles.footer}>
+        <Button onClick={closeModal} className={styles.cancel}>
+          취소
+        </Button>
+        <Button type="submit" disabled={!isValid}>
+          생성
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/Invitations.module.css
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/Invitations.module.css
@@ -2,20 +2,18 @@
   background-color: var(--white);
   border-radius: 8px;
 }
-.header {
-  padding: 24px 20px;
+
+.list {
+  margin-top: 2px;
 }
-.header h2 {
-  font-size: 20px;
-  font-weight: 700;
-  line-height: 32px;
-  color: var(--black-100);
+
+.list li:not(:last-child) {
+  border-bottom: 1px solid var(--gray-200);
 }
 
 @media screen and (min-width: 768px) {
-  .header h2 {
-    font-size: 24px;
-    line-height: 32px;
+  .list {
+    margin-top: 1px;
   }
 }
 

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/Invitations.tsx
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/Invitations.tsx
@@ -1,16 +1,30 @@
 'use client';
 
 import useIdStore from '@/store/idStore';
-import { Invitation } from '@/types/invitation';
 import useInvitation from '../_hooks/useInvitation';
-import styles from './Invitations.module.css';
 import ListHeader from './ListHeader';
 import ListItem from './ListItem';
+import { Invitation } from '@/types/invitation';
+import styles from './Invitations.module.css';
+import useModalStore from '@/store/modalStore';
+import InvitationModal from './InvitationModal';
+import EmptyInvitations from './EmptyInvitations';
 
 export default function Invitations() {
   const dashboardId = useIdStore((state) => state.id);
-  const { page, invitations, totalPages, handlePageChange, handleCancel } =
-    useInvitation(dashboardId);
+  const {
+    page,
+    invitations,
+    totalPages,
+    handlePageChange,
+    handleCancel,
+    handleInvite,
+  } = useInvitation(dashboardId);
+  const { openModal } = useModalStore();
+
+  const handleOpenModal = () => {
+    openModal(<InvitationModal handleInvite={handleInvite} />);
+  };
 
   return (
     <div className={styles.container}>
@@ -18,6 +32,7 @@ export default function Invitations() {
         page={page}
         totalPages={totalPages}
         handlePageChange={handlePageChange}
+        onOpenModal={handleOpenModal}
       />
       {invitations.length > 0 ? (
         <ul className={styles.list}>
@@ -25,12 +40,12 @@ export default function Invitations() {
             <ListItem
               key={id}
               invitee={invitee}
-              handleCancel={() => handleCancel(id)}
+              onCancel={() => handleCancel(id)}
             />
           ))}
         </ul>
       ) : (
-        <div>초대없음</div>
+        <EmptyInvitations />
       )}
     </div>
   );

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/Invitations.tsx
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/Invitations.tsx
@@ -2,33 +2,36 @@
 
 import useIdStore from '@/store/idStore';
 import { Invitation } from '@/types/invitation';
-import Pagination from './Pagination';
 import useInvitation from '../_hooks/useInvitation';
 import styles from './Invitations.module.css';
+import ListHeader from './ListHeader';
+import ListItem from './ListItem';
 
 export default function Invitations() {
-  const id = useIdStore((state) => state.id);
-  const { page, invitations, totalPages, handlePageChange } = useInvitation(id);
+  const dashboardId = useIdStore((state) => state.id);
+  const { page, invitations, totalPages, handlePageChange, handleCancel } =
+    useInvitation(dashboardId);
 
   return (
     <div className={styles.container}>
-      <div className={styles.header}>
-        <h2>초대 내역</h2>
-        <Pagination
-          currentPage={page}
-          totalPages={totalPages}
-          onPageChange={handlePageChange}
-        />
-      </div>
-      <div className={styles.list}>
-        {invitations.length > 0 ? (
-          invitations.map(({ id, invitee }: Invitation) => (
-            <div key={id}>{invitee.email}</div>
-          ))
-        ) : (
-          <div>초대없음</div>
-        )}
-      </div>
+      <ListHeader
+        page={page}
+        totalPages={totalPages}
+        handlePageChange={handlePageChange}
+      />
+      {invitations.length > 0 ? (
+        <ul className={styles.list}>
+          {invitations.map(({ id, invitee }: Invitation) => (
+            <ListItem
+              key={id}
+              invitee={invitee}
+              handleCancel={() => handleCancel(id)}
+            />
+          ))}
+        </ul>
+      ) : (
+        <div>초대없음</div>
+      )}
     </div>
   );
 }

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/ListHeader.module.css
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/ListHeader.module.css
@@ -53,6 +53,7 @@
   line-height: 18px;
   padding: 4px 12px;
   order: 1;
+  margin-left: auto;
 }
 
 .addBox {

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/ListHeader.module.css
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/ListHeader.module.css
@@ -1,0 +1,113 @@
+.container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  row-gap: 12px;
+  padding: 24px 20px;
+  white-space: nowrap;
+}
+
+.header {
+  flex: 1 0 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.header h2 {
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 32px;
+  color: var(--black-100);
+}
+
+.pageInfo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.pageInfo span {
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 18px;
+}
+
+.subtitle {
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 24px;
+  color: var(--gray-400);
+  order: 1;
+}
+
+.button.button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: auto;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 18px;
+  padding: 4px 12px;
+  order: 1;
+}
+
+.addBox {
+  width: 14px;
+  height: 14px;
+  filter: invert(1) brightness(2);
+}
+
+@media screen and (min-width: 768px) {
+  .container {
+    justify-content: flex-start;
+    align-items: center;
+    row-gap: 32px;
+    column-gap: 16px;
+    padding: 32px 28px 0;
+  }
+
+  .header {
+    flex: 1 1 auto;
+  }
+
+  .header h2 {
+    font-size: 24px;
+    line-height: 32px;
+  }
+
+  .pageInfo {
+    gap: 16px;
+  }
+
+  .pageInfo span {
+    font-size: 14px;
+    line-height: 24px;
+  }
+
+  .subtitle {
+    flex-wrap: wrap;
+  }
+
+  .subtitle {
+    flex: 1 0 100%;
+    font-size: 16px;
+    line-height: 26px;
+  }
+
+  .button.button {
+    gap: 8px;
+    font-size: 14px;
+    line-height: 16px;
+    padding: 8px 16px;
+    order: 0;
+  }
+
+  .addBox {
+    width: 16px;
+    height: 16px;
+  }
+}

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/ListHeader.tsx
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/ListHeader.tsx
@@ -1,3 +1,4 @@
+import { MouseEventHandler } from 'react';
 import Image from 'next/image';
 import Button from '@/components/Button';
 import Pagination from './Pagination';
@@ -7,12 +8,14 @@ interface ListHeaderProps {
   totalPages: number;
   page: number;
   handlePageChange: (direction: 'next' | 'prev') => void;
+  onOpenModal: MouseEventHandler<HTMLButtonElement>;
 }
 
 export default function ListHeader({
   totalPages,
   page,
   handlePageChange,
+  onOpenModal,
 }: ListHeaderProps) {
   return (
     <div className={styles.container}>
@@ -30,8 +33,8 @@ export default function ListHeader({
           />
         </div>
       </div>
-      <h4 className={styles.subtitle}>이메일</h4>
-      <Button className={styles.button}>
+      {totalPages > 0 && <h4 className={styles.subtitle}>이메일</h4>}
+      <Button className={styles.button} onClick={onOpenModal}>
         <Image
           src="/icons/add_box.svg"
           width={14}

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/ListHeader.tsx
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/ListHeader.tsx
@@ -1,0 +1,46 @@
+import Image from 'next/image';
+import Button from '@/components/Button';
+import Pagination from './Pagination';
+import styles from './ListHeader.module.css';
+
+interface ListHeaderProps {
+  totalPages: number;
+  page: number;
+  handlePageChange: (direction: 'next' | 'prev') => void;
+}
+
+export default function ListHeader({
+  totalPages,
+  page,
+  handlePageChange,
+}: ListHeaderProps) {
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <h2>초대 내역</h2>
+        <div className={styles.pageInfo}>
+          <span>
+            {totalPages} 페이지 중 {page}
+          </span>
+          <Pagination
+            className={styles.pagination}
+            currentPage={page}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+          />
+        </div>
+      </div>
+      <h4 className={styles.subtitle}>이메일</h4>
+      <Button className={styles.button}>
+        <Image
+          src="/icons/add_box.svg"
+          width={14}
+          height={14}
+          alt="초대하기"
+          className={styles.addBox}
+        />
+        초대하기
+      </Button>
+    </div>
+  );
+}

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/ListItem.module.css
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/ListItem.module.css
@@ -1,0 +1,42 @@
+.item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 9px 20px 13px;
+}
+
+.content {
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 24px;
+  color: var(--black-100);
+}
+
+.button.button {
+  width: auto;
+  border: 1px solid var(--gray-300);
+  border-radius: 4px;
+  background-color: transparent;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 18px;
+  color: var(--violet);
+  padding: 7px 15.5px;
+}
+
+@media screen and (min-width: 768px) {
+  .item {
+    padding: 19px 28px;
+  }
+
+  .content {
+    font-size: 16px;
+    line-height: 26px;
+  }
+
+  .button.button {
+    font-size: 14px;
+    line-height: 24px;
+    padding: 4px 29.5px;
+  }
+}

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/ListItem.tsx
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/ListItem.tsx
@@ -1,18 +1,18 @@
 import { MouseEventHandler } from 'react';
+import Button from '@/components/Button';
 import { Invitee } from '@/types/invitation';
 import styles from './ListItem.module.css';
-import Button from '@/components/Button';
 
 interface ListItemProps {
   invitee: Invitee;
-  handleCancel: MouseEventHandler<HTMLButtonElement>;
+  onCancel: MouseEventHandler<HTMLButtonElement>;
 }
 
-export default function ListItem({ invitee, handleCancel }: ListItemProps) {
+export default function ListItem({ invitee, onCancel }: ListItemProps) {
   return (
     <li className={styles.item}>
       <span className={styles.content}>{invitee.email}</span>
-      <Button className={styles.button} onClick={handleCancel}>
+      <Button className={styles.button} onClick={onCancel}>
         취소
       </Button>
     </li>

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/ListItem.tsx
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/ListItem.tsx
@@ -1,0 +1,20 @@
+import { MouseEventHandler } from 'react';
+import { Invitee } from '@/types/invitation';
+import styles from './ListItem.module.css';
+import Button from '@/components/Button';
+
+interface ListItemProps {
+  invitee: Invitee;
+  handleCancel: MouseEventHandler<HTMLButtonElement>;
+}
+
+export default function ListItem({ invitee, handleCancel }: ListItemProps) {
+  return (
+    <li className={styles.item}>
+      <span className={styles.content}>{invitee.email}</span>
+      <Button className={styles.button} onClick={handleCancel}>
+        취소
+      </Button>
+    </li>
+  );
+}

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/Pagination.module.css
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/Pagination.module.css
@@ -1,15 +1,24 @@
+.arrowWrapper {
+  display: flex;
+}
+
 .arrowLeft.arrowLeft,
 .arrowRight.arrowRight {
   border: 1px solid var(--gray-300);
-  border-right: none;
   border-radius: 0;
+  width: 36px;
+  height: 36px;
   background: var(--white);
-  height: 35px;
   transition: background-color 0.3s ease;
 }
 
+.arrowLeft.arrowLeft {
+  border-right: none;
+  border-radius: 4px 0px 0px 4px;
+}
+
 .arrowRight.arrowRight {
-  border-top: none;
+  border-radius: 0px 4px 4px 0px;
 }
 
 .arrowLeft.arrowLeft:hover,
@@ -23,22 +32,9 @@
 }
 
 @media screen and (min-width: 768px) {
-  .arrowWrapper {
-    margin-top: 20px;
-  }
-
   .arrowLeft.arrowLeft,
   .arrowRight.arrowRight {
-    border: 1px solid var(--gray-300);
     width: 40px;
     height: 40px;
-  }
-
-  .arrowLeft.arrowLeft {
-    border-radius: 4px 0px 0px 4px;
-  }
-
-  .arrowRight.arrowRight {
-    border-radius: 0px 4px 4px 0px;
   }
 }

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/Pagination.tsx
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_components/Pagination.tsx
@@ -6,18 +6,20 @@ interface PaginationProps {
   currentPage: number;
   totalPages: number;
   onPageChange: (direction: 'next' | 'prev') => void;
+  className?: string;
 }
 
 export default function Pagination({
   currentPage,
   totalPages,
   onPageChange,
+  className = '',
 }: PaginationProps) {
   const isFirstPage = currentPage === 1;
   const isLastPage = currentPage >= totalPages;
 
   return (
-    <div className={styles.arrowWrapper}>
+    <div className={`${styles.arrowWrapper} ${className}`}>
       <Button
         className={styles.arrowLeft}
         onClick={() => onPageChange('prev')}

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_hooks/useInvitation.ts
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_hooks/useInvitation.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
-import { deleteInvitation, getInvitations } from '../_lib/invitationService';
+import {
+  createInvitation,
+  deleteInvitation,
+  getInvitations,
+} from '../_lib/invitationService';
 import useApi from './useApi';
 import { GetInvitationsResponse, Invitation } from '@/types/invitation';
 
@@ -65,6 +69,15 @@ const useInvitation = (dashboardId: string, pageSize = 5) => {
     }
   };
 
+  const handleInvite = async (email: string) => {
+    try {
+      await createInvitation(dashboardId, email);
+      handleLoad(invitationState.page);
+    } catch (error) {
+      throw error;
+    }
+  };
+
   useEffect(() => {
     handleLoad(invitationState.page);
   }, [handleLoad, invitationState.page]);
@@ -77,6 +90,7 @@ const useInvitation = (dashboardId: string, pageSize = 5) => {
     error,
     handlePageChange,
     handleCancel,
+    handleInvite,
   };
 };
 

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_hooks/useInvitation.ts
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_hooks/useInvitation.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { getInvitations } from '../_lib/invitationService';
+import { deleteInvitation, getInvitations } from '../_lib/invitationService';
 import useApi from './useApi';
 import { GetInvitationsResponse, Invitation } from '@/types/invitation';
 
@@ -15,7 +15,7 @@ const DEFAULT_INVITATION_STATE: InvitationState = {
   invitations: [],
 };
 
-const useInvitation = (id: string, pageSize = 5) => {
+const useInvitation = (dashboardId: string, pageSize = 5) => {
   const [invitationState, setInvitationState] = useState<InvitationState>(
     DEFAULT_INVITATION_STATE
   );
@@ -23,10 +23,10 @@ const useInvitation = (id: string, pageSize = 5) => {
 
   const handleLoad = useCallback(
     async (page: number) => {
-      if (!id) return;
+      if (!dashboardId) return;
       try {
         const response: GetInvitationsResponse | undefined =
-          await getInvitationsAsync(id, page);
+          await getInvitationsAsync(dashboardId, page);
 
         const invitations = response?.invitations ?? [];
         const totalCount = response?.totalCount ?? 0;
@@ -41,7 +41,7 @@ const useInvitation = (id: string, pageSize = 5) => {
         throw error;
       }
     },
-    [getInvitationsAsync, id, pageSize]
+    [getInvitationsAsync, dashboardId, pageSize]
   );
 
   const handlePageChange = (direction: 'next' | 'prev') => {
@@ -56,6 +56,15 @@ const useInvitation = (id: string, pageSize = 5) => {
     });
   };
 
+  const handleCancel = async (invitationId: number) => {
+    try {
+      await deleteInvitation(dashboardId, invitationId);
+      handleLoad(invitationState.page);
+    } catch (error) {
+      throw error;
+    }
+  };
+
   useEffect(() => {
     handleLoad(invitationState.page);
   }, [handleLoad, invitationState.page]);
@@ -67,6 +76,7 @@ const useInvitation = (id: string, pageSize = 5) => {
     isLoading,
     error,
     handlePageChange,
+    handleCancel,
   };
 };
 

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_lib/invitationService.ts
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_lib/invitationService.ts
@@ -2,14 +2,24 @@ import axiosInstance from '@/lib/axiosInstance';
 import { GetInvitationsResponse } from '@/types/invitation';
 
 export const getInvitations = async (
-  id: string,
+  dashboardId: string,
   page: number = 1
 ): Promise<GetInvitationsResponse> => {
   try {
     const response = await axiosInstance.get(
-      `/dashboards/${id}/invitations?page=${page}&size=5`
+      `/dashboards/${dashboardId}/invitations?page=${page}&size=5`
     );
     return response.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
+export const createInvitation = async (dashboardId: string, email: string) => {
+  try {
+    await axiosInstance.post(`/dashboards/${dashboardId}/invitations`, {
+      email,
+    });
   } catch (error) {
     throw error;
   }

--- a/src/app/(with-header-sidebar)/dashboard/[id]/edit/_lib/invitationService.ts
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/edit/_lib/invitationService.ts
@@ -14,3 +14,16 @@ export const getInvitations = async (
     throw error;
   }
 };
+
+export const deleteInvitation = async (
+  dashboardId: string,
+  invitationId: number
+) => {
+  try {
+    await axiosInstance.delete(
+      `/dashboards/${dashboardId}/invitations/${invitationId}`
+    );
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/app/(with-header-sidebar)/mypage/_components/Modal.tsx
+++ b/src/app/(with-header-sidebar)/mypage/_components/Modal.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useEffect } from 'react';
+import { MouseEvent, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import useModalStore from '@/store/modalStore';
 import styles from './Modal.module.css';
 
 export default function Modal() {
   const { modals, closeModal } = useModalStore();
+  const modalRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -15,19 +16,32 @@ export default function Modal() {
       }
     };
 
+    if (modals.length > 0) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+
     window.addEventListener('keydown', handleKeyDown);
 
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = '';
     };
-  }, [closeModal]);
+  }, [closeModal, modals]);
+
+  const handleOutsideClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+      closeModal();
+    }
+  };
 
   if (modals.length === 0) return null;
 
   return createPortal(
-    <div className={styles.overlay}>
+    <div className={styles.overlay} onClick={handleOutsideClick}>
       {modals.map((content, index) => (
-        <div key={index} className={styles.modal}>
+        <div key={index} className={styles.modal} ref={modalRef}>
           {content}
         </div>
       ))}

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -3,6 +3,7 @@ export const ERROR_MESSAGES = {
   PASSWORDS_MATCH: '비밀번호가 일치하지 않습니다.',
   SAME_AS_OLD_PASSWORD: '기존 비밀번호와 동일합니다.',
   PASSWORD_TOO_SHORT: '비밀번호를 8자 이상 입력해주세요.',
+  EMAIL_REQUIRE: '이메일을 입력해주세요.',
   NICKNAME_REQUIRE: '닉네임을 입력해주세요.',
   PASSWORD_REQUIRE: '비밀번호를 입력해주세요.',
   DASHBOARD_TITLE_REQUIRE: '대시보드 이름은 필수입니다.',


### PR DESCRIPTION
## 📌 Related Issue

> close #45 

## 📝 Description

- 대시보드 수정페이지의 초대 기능과 초대 취소 기능 구현

## 📸 Screenshot
**모바일**
![192 168 0 3_3000_dashboard_12588_edit](https://github.com/user-attachments/assets/a1c5ea8a-a67b-47d4-a6e4-eecbf6016b64)

**PC**
![192 168 0 3_3000_dashboard_12588_edit (1)](https://github.com/user-attachments/assets/c7788636-93bc-483b-9676-56fa07d22ac3)

**초대내역 없을때**
![192 168 0 3_3000_dashboard_12619_edit](https://github.com/user-attachments/assets/cd94e3c6-1c6b-41a8-9591-9a8549a1c458)

**모달**
![192 168 0 3_3000_dashboard_12588_edit (2)](https://github.com/user-attachments/assets/d0d31df4-0fbf-4136-b67d-03fca28d3017)

## 📢 Notes
초대 내역 헤더 만들때 정신 나갈뻔했습니다 flex 너무 어렵네요
멤버 구성원 조회 만들때 꿀좀빨려고 컴포넌트 미리미리 다 분리해놨습니다 😎
모달 스크롤방지, 외부 클릭시 종료도 추가해봤습니다
애니메이션하고, 탭 포커싱은 나중에... 😓