### PR TITLE
[feat] add dashboard store and header title value

### DIFF
--- a/src/app/(with-header-sidebar)/dashboard/[id]/page.tsx
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
   Draggable,
   DropResult,
 } from 'react-beautiful-dnd';
+import useDashboardStore from '@/store/dashboardStore';
 import styles from './page.module.css';
 
 interface Column {
@@ -50,10 +51,19 @@ interface Card {
 
 export default function DashBoardView() {
   const { id } = useParams();
+  const dashboard = useDashboardStore((state) => state.dashboard);
+  const setDashboard = useDashboardStore((state) => state.setDashboard);
+
   const [columns, setColumns] = useState<Column[]>([]);
   // const [cards, setCards] = useState<Card[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (dashboard?.id !== Number(id)) {
+      setDashboard(Number(id));
+    }
+  }, [id, dashboard?.id]);
 
   useEffect(() => {
     if (!id || Array.isArray(id)) return;

--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -1,11 +1,12 @@
 import { ReactNode } from 'react';
 import Header from './header/Header';
 import styles from './MainContainer.module.css';
+import DashboardMembers from './header/DashboardMembers';
 
 export default function MainContainer({ children }: { children: ReactNode }) {
   return (
     <>
-      <Header />
+      <Header component={DashboardMembers} />
       <main className={styles.mainContainer}>{children}</main>
     </>
   );

--- a/src/components/header/DashboardMembers.tsx
+++ b/src/components/header/DashboardMembers.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import useIdStore from '@/store/idStore';
+import { getMembers } from '@/app/(with-header-sidebar)/dashboard/[id]/edit/_lib/memberService';
+import { useEffect, useState } from 'react';
+import { Member } from '@/types/member';
+import { useParams } from 'next/navigation';
+import useDashboardStore from '@/store/dashboardStore';
+import styles from './DashboardMembers.module.css';
+
+export default function DashboardMembers() {
+  // const dashboard = useDashboardStore((state) => state.dashboard);
+  // const [members, setMembers] = useState<Member[]>([]);
+  // const [totalPages, setTotalPages] = useState(0);
+
+  // useEffect(() => {
+  //   if (!dashboard) return;
+
+  //   async function fetchMembers() {
+  //     try {
+  //       const response = await getMembers(dashboard!.id.toString());
+  //       setMembers(response.members);
+  //       setTotalPages(response.totalCount);
+  //     } catch (error) {
+  //       console.error('Error fetching members:', error);
+  //     }
+  //   }
+
+  //   fetchMembers();
+  //   console.log({ members });
+  // }, [dashboard]);
+
+  return (
+    <>
+      {/* <div>토탈</div>
+      {members.map((member) => (
+        <div key={member.id}>{member.nickname}</div>
+      ))}
+      <div></div> */}
+    </>
+  );
+}

--- a/src/components/header/Header.module.css
+++ b/src/components/header/Header.module.css
@@ -2,9 +2,9 @@
   padding: 16px;
   border-bottom: 1px solid var(--gray-300);
   display: flex;
-  justify-content: space-around;
+  justify-content: space-between;
   align-items: center;
-  gap: 16px;
+  gap: 10px;
   flex: 0 0 auto;
 }
 

--- a/src/components/header/Header.module.css
+++ b/src/components/header/Header.module.css
@@ -59,10 +59,7 @@
   margin-left: 16px;
   display: flex;
   align-items: center;
-}
-
-.userInfoWrapper:hover {
-  cursor: pointer;
+  background-color: transparent;
 }
 
 .myMenu {

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,20 +1,19 @@
 'use client';
 
 import { usePathname, useRouter } from 'next/navigation';
+import { useState } from 'react';
 import Image from 'next/image';
 import Button from '../Button';
 import UserInfo from './UserInfo';
+import Title from './Title';
 import styles from './Header.module.css';
-import { useState } from 'react';
 
 interface HeaderProps {
   component?: React.ComponentType;
 }
 
 export default function Header({ component: Component }: HeaderProps) {
-  const pathname = usePathname();
   const router = useRouter();
-
   const [isMenuVisible, setIsMenuVisible] = useState(false);
 
   const handleUserInfoClick = () => {
@@ -28,7 +27,7 @@ export default function Header({ component: Component }: HeaderProps) {
 
   return (
     <header className={styles.header}>
-      <h2 className={styles.title}>내 대시보드</h2>
+      <Title pathname={usePathname()} />
       <div className={styles.buttonContainer}>
         <Button className={styles.button}>
           <Image

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -56,9 +56,12 @@ export default function Header({ component: Component }: HeaderProps) {
         </div>
       )}
       <div className={styles.userInfoContainer}>
-        <div className={styles.userInfoWrapper} onClick={handleUserInfoClick}>
+        <Button
+          className={styles.userInfoWrapper}
+          onClick={handleUserInfoClick}
+        >
           <UserInfo />
-        </div>
+        </Button>
         {isMenuVisible && (
           <div className={styles.myMenu}>
             <div onClick={() => navigateTo('/mydashboard')}>내 대시보드</div>

--- a/src/components/header/Title.module.css
+++ b/src/components/header/Title.module.css
@@ -1,0 +1,29 @@
+.title,
+.dashboardTitle {
+  color: var(--black-100);
+  font-size: 15px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.title {
+  flex: 1;
+}
+
+.dashboardTitleContainer {
+  display: none;
+}
+
+@media screen and (min-width: 768px) {
+  .title,
+  .dashboardTitle {
+    font-size: 20px;
+  }
+
+  .dashboardTitleContainer {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+}

--- a/src/components/header/Title.tsx
+++ b/src/components/header/Title.tsx
@@ -1,0 +1,35 @@
+import useDashboardStore from '@/store/dashboardStore';
+import styles from './Title.module.css';
+import Image from 'next/image';
+
+interface TitleProps {
+  pathname: string;
+}
+
+export default function Title({ pathname }: TitleProps) {
+  const pathSegments = pathname.split('/');
+  const firstSegment = pathSegments[1];
+
+  const dashboard = useDashboardStore((state) => state.dashboard);
+
+  switch (firstSegment) {
+    case 'mypage':
+      return <h2 className={styles.title}>계정관리</h2>;
+    case 'mydashboard':
+      return <h2 className={styles.title}>내 대시보드</h2>;
+    case 'dashboard':
+      const { title, createdByMe } = dashboard!;
+      return (
+        <div className={styles.dashboardTitleContainer}>
+          <h2 className={styles.dashboardTitle}>{title}</h2>
+          {createdByMe && (
+            <span className={styles.crown}>
+              <Image src="/icons/crown.svg" alt="왕관" width={15} height={12} />
+            </span>
+          )}
+        </div>
+      );
+    default:
+      return <h2 className={styles.title}>TITLE</h2>;
+  }
+}

--- a/src/components/header/UserInfo.module.css
+++ b/src/components/header/UserInfo.module.css
@@ -9,15 +9,6 @@
   gap: 15px;
 }
 
-.userIcon {
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
 .nickname {
   color: var(--black-100);
   font-size: 16px;

--- a/src/components/header/UserInfo.tsx
+++ b/src/components/header/UserInfo.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { useState, useEffect } from 'react';
 import styles from './UserInfo.module.css';
 import UserInfoSkeleton from './skeleton/UserInfoSkeleton';
+import Avatar from '../Avatar';
 
 // TODO 로그인 로직 완료 후 user정보 가져오기
 const user: User = {
@@ -12,25 +13,15 @@ const user: User = {
   email: 'heejin@gmail.com',
   nickname: 'heejin',
   profileImageUrl:
-    'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/taskify/profile_image/10-1_4804_1731757528194.jpeg',
-  // profileImageUrl: null,
+    // 'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/taskify/profile_image/10-1_4804_1731757528194.jpeg',
+    null,
   createdAt: '2024-11-15T14:29:07.482Z',
 };
 
 export default function UserInfo() {
-  const { email, nickname, profileImageUrl } = user;
+  const { nickname, profileImageUrl } = user;
 
-  const [colors, setColors] = useState<{
-    randomColor: string;
-    invertedColor: string;
-  } | null>(null);
-
-  useEffect(() => {
-    const { randomColor, invertedColor } = getRandomColor();
-    setColors({ randomColor, invertedColor });
-  }, []);
-
-  if (!colors) {
+  if (!nickname) {
     return <UserInfoSkeleton />;
   }
 
@@ -46,30 +37,10 @@ export default function UserInfo() {
             className={styles.image}
           />
         ) : (
-          <div
-            style={{
-              backgroundColor: colors.randomColor,
-              color: colors.invertedColor,
-            }}
-            className={styles.userIcon}
-          >
-            <span>{email[0].toUpperCase()}</span>
-          </div>
+          <Avatar name={nickname} profileImageUrl={profileImageUrl} />
         )}
         <span className={styles.nickname}>{nickname}</span>
       </div>
     </>
   );
-}
-
-function getRandomColor() {
-  const randomColor = `#${Math.floor(Math.random() * 16777215).toString(16)}`;
-
-  const r = parseInt(randomColor.slice(1, 3), 16);
-  const g = parseInt(randomColor.slice(3, 5), 16);
-  const b = parseInt(randomColor.slice(5, 7), 16);
-
-  const invertedColor = `rgb(${255 - r}, ${255 - g}, ${255 - b})`;
-
-  return { randomColor, invertedColor };
 }

--- a/src/components/sidebar/Dashboards.module.css
+++ b/src/components/sidebar/Dashboards.module.css
@@ -32,6 +32,10 @@
   font-weight: 500;
 }
 
+.title {
+  white-space: nowrap;
+}
+
 .arrowLeft.arrowLeft,
 .arrowRight.arrowRight {
   border: 1px solid var(--gray-300);

--- a/src/components/sidebar/Dashboards.tsx
+++ b/src/components/sidebar/Dashboards.tsx
@@ -3,8 +3,8 @@ import { usePathname } from 'next/navigation';
 import type { Dashboard } from '@/types/dashboards';
 import Image from 'next/image';
 import Button from '../Button';
-import styles from './Dashboards.module.css';
 import useDashboards from '@/app/(with-header-sidebar)/mydashboard/_hooks/useDashboards';
+import styles from './Dashboards.module.css';
 
 const PAGE_SIZE = 12;
 

--- a/src/store/dashboardStore.ts
+++ b/src/store/dashboardStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { Dashboard } from '@/types/dashboards';
+import { getBoard } from '@/lib/boardService';
+
+interface dashboardState {
+  dashboard: Dashboard | null;
+  setDashboard: (dashboardId: number) => void;
+}
+
+const useDashboardStore = create(
+  persist<dashboardState>(
+    (set, get) => ({
+      dashboard: null,
+      setDashboard: async (dashboardId) => {
+        if (get().dashboard?.id === dashboardId) return;
+
+        const response = await getBoard(dashboardId.toString());
+        set({
+          dashboard: { ...response },
+        });
+      },
+    }),
+    {
+      name: 'dashboardStorage',
+    }
+  )
+);
+
+export default useDashboardStore;

--- a/src/store/dashboardStore.ts
+++ b/src/store/dashboardStore.ts
@@ -15,6 +15,7 @@ const useDashboardStore = create(
       setDashboard: async (dashboardId) => {
         if (get().dashboard?.id === dashboardId) return;
 
+        // TODO error handling
         const response = await getBoard(dashboardId.toString());
         set({
           dashboard: { ...response },


### PR DESCRIPTION
## 📌 Related Issue

> close #67 

## 📝 Description

- board 정보 local storage에 넣기 + 전역상태
- header title 전역상태값 가져와서 셋팅하기
- userInfo에 아바타 가져다쓰기

## 📸 Screenshot
<img width="424" alt="image" src="https://github.com/user-attachments/assets/b9a5508c-8629-4971-8a0c-ed16d986d0f3">

## 📢 Notes

- 지금 dashboard쪽 페이지가 반응형이 안되어있습니다 중간 컨텐츠에 따라 안에 내용물만 x스크롤 되게 해야할것같은데.. 일단 요건 패스 (@21ow 님이 대시보드 메인쪽 반응형 추가해주시면 어느정도 해소될것같아서 다른거 먼저하고 스크롤 해볼게요)
- useDashboardStore 추가해봤는데 id값 말고도 title에 필요한 정보라던지, 어딘가에서 color 값도 쓴거같아서 추가해놨어요. 보시고 괜찮으시면 이걸로 온갖데 대시보드 정보 가져다 쓰는걸로 해도 좋을것같습니다
- 헤더 구성원하려고했는데 ^.^ zustand 어케하는지 찾아보다가 시간 다갔.....😇