### PR TITLE
[feat] card preview css

### DIFF
--- a/src/app/(user-access)/layout.module.css
+++ b/src/app/(user-access)/layout.module.css
@@ -7,6 +7,7 @@
   width: 100%;
   background-color: var(--white);
 }
+
 .authContent {
   width: 100%;
   max-width: 400px;
@@ -17,6 +18,7 @@
   border-radius: 8px;
   padding: 20px;
 }
+
 .logoContainer {
   display: flex;
   flex-direction: column;
@@ -24,10 +26,12 @@
   align-items: center;
   margin: 16px 0;
 }
+
 .logo {
   width: 100%;
   height: auto;
 }
+
 @media screen and (min-width: 768px) {
   .authContent {
     max-width: 351px;

--- a/src/app/(with-header-sidebar)/dashboard/[id]/components/Card.module.css
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/components/Card.module.css
@@ -116,6 +116,7 @@
 @media screen and (min-width: 1200px) {
   .cardContainer {
     flex-direction: column;
+    gap: 0;
   }
 
   .imageWrapper {

--- a/src/app/(with-header-sidebar)/dashboard/[id]/components/Card.module.css
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/components/Card.module.css
@@ -4,9 +4,42 @@
   border: 1px solid var(--gray-300);
   background: var(--white);
   margin-bottom: 20px;
-  height: 150px;
 }
 
 .card.dragging {
   margin: 0;
+}
+
+.imageWrapper {
+  position: relative;
+  width: 260px;
+  height: 150px;
+}
+
+.imageWrapper img {
+  border-radius: 6px;
+  object-fit: cover;
+}
+
+.title {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+@media screen and (min-width: 768px) {
+  .imageWrapper {
+    width: 90px;
+    height: 55px;
+  }
+
+  .title {
+    font-size: 16px;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .imageWrapper {
+    width: 274px;
+    height: 160px;
+  }
 }

--- a/src/app/(with-header-sidebar)/dashboard/[id]/components/Card.module.css
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/components/Card.module.css
@@ -14,6 +14,7 @@
   position: relative;
   width: 260px;
   height: 150px;
+  margin-bottom: 4px;
 }
 
 .imageWrapper img {
@@ -21,12 +22,65 @@
   object-fit: cover;
 }
 
+.cardInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 .title {
   font-size: 14px;
   font-weight: 500;
+  line-height: 24px;
+}
+
+.contentContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tagContainer {
+  display: flex;
+  gap: 6px;
+}
+
+.optionalInfo {
+  display: flex;
+  justify-content: space-between;
+}
+
+.dueDateWrapper {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.icon path {
+  fill: var(--gray-500);
+}
+
+.dueDate {
+  color: var(--gray-500);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.avatar.avatar {
+  width: 22px;
+  height: 22px;
+  font-size: 12px;
 }
 
 @media screen and (min-width: 768px) {
+  .cardInfo {
+    gap: 10px;
+  }
+
+  .contentContainer {
+    gap: 12px;
+  }
+
   .imageWrapper {
     width: 90px;
     height: 55px;
@@ -34,6 +88,7 @@
 
   .title {
     font-size: 16px;
+    line-height: 26px;
   }
 }
 
@@ -41,5 +96,9 @@
   .imageWrapper {
     width: 274px;
     height: 160px;
+  }
+
+  .imageWrapper {
+    margin-bottom: 15px;
   }
 }

--- a/src/app/(with-header-sidebar)/dashboard/[id]/components/Card.module.css
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/components/Card.module.css
@@ -10,9 +10,18 @@
   margin: 0;
 }
 
+.cardContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+.imageContainer {
+  margin: auto;
+}
+
 .imageWrapper {
   position: relative;
-  width: 260px;
+  width: 280px;
   height: 150px;
   margin-bottom: 4px;
 }
@@ -73,32 +82,52 @@
 }
 
 @media screen and (min-width: 768px) {
+  .cardContainer {
+    flex-direction: row;
+    gap: 22px;
+  }
+
   .cardInfo {
+    flex: 1;
     gap: 10px;
   }
 
   .contentContainer {
+    flex-direction: row;
     gap: 12px;
   }
 
   .imageWrapper {
     width: 90px;
-    height: 55px;
+    height: 57px;
+    margin-bottom: 0;
   }
 
   .title {
     font-size: 16px;
     line-height: 26px;
   }
+
+  .optionalInfo {
+    flex: 1;
+  }
 }
 
 @media screen and (min-width: 1200px) {
+  .cardContainer {
+    flex-direction: column;
+  }
+
   .imageWrapper {
-    width: 274px;
+    width: 280px;
     height: 160px;
   }
 
   .imageWrapper {
     margin-bottom: 15px;
+  }
+
+  .contentContainer {
+    flex-direction: column;
   }
 }

--- a/src/app/(with-header-sidebar)/dashboard/[id]/components/Card.tsx
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/components/Card.tsx
@@ -6,6 +6,9 @@ import Modal from '@/app/(with-header-sidebar)/mydashboard/_components/modal/Mod
 import CardInfo from './card-detail/CardInfo';
 import HeaderMenu from './card-detail/HeaderMenu';
 import Image from 'next/image';
+import Tag from '@/components/card/Tag';
+import CalendarIcon from '/public/icons/calendar.svg';
+import Avatar from '@/components/Avatar';
 import styles from './Card.module.css';
 
 interface Props {
@@ -21,7 +24,7 @@ function Card({ item, index, columnTitle }: Props) {
     return null;
   }
 
-  const { id, title, imageUrl } = item;
+  const { id, title, imageUrl, tags, dueDate, assignee } = item;
   return (
     <>
       <Draggable draggableId={`${id}`} index={index}>
@@ -43,7 +46,32 @@ function Card({ item, index, columnTitle }: Props) {
                 />
               </div>
             )}
-            <div className={styles.title}>{title}</div>
+            <div className={styles.cardInfo}>
+              <h3 className={styles.title}>{title}</h3>
+              <div className={styles.contentContainer}>
+                <div className={styles.tagContainer}>
+                  {tags.map((tag, index) => (
+                    <Tag key={index} name={tag} />
+                  ))}
+                </div>
+                <div className={styles.optionalInfo}>
+                  <div className={styles.dueDateWrapper}>
+                    {dueDate && (
+                      <>
+                        <CalendarIcon className={styles.icon} />
+                        <span className={styles.dueDate}>{dueDate}</span>
+                      </>
+                    )}
+                  </div>
+                  {assignee && (
+                    <Avatar
+                      name={assignee.nickname}
+                      className={styles.avatar}
+                    />
+                  )}
+                </div>
+              </div>
+            </div>
           </div>
         )}
       </Draggable>

--- a/src/app/(with-header-sidebar)/dashboard/[id]/components/Card.tsx
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/components/Card.tsx
@@ -5,6 +5,7 @@ import { useModal } from '@/app/(with-header-sidebar)/mydashboard/_hooks/useModa
 import Modal from '@/app/(with-header-sidebar)/mydashboard/_components/modal/Modal';
 import CardInfo from './card-detail/CardInfo';
 import HeaderMenu from './card-detail/HeaderMenu';
+import Image from 'next/image';
 import styles from './Card.module.css';
 
 interface Props {
@@ -20,9 +21,10 @@ function Card({ item, index, columnTitle }: Props) {
     return null;
   }
 
+  const { id, title, imageUrl } = item;
   return (
     <>
-      <Draggable draggableId={`${item.id}`} index={index}>
+      <Draggable draggableId={`${id}`} index={index}>
         {(provided, snapshot) => (
           <div
             ref={provided.innerRef}
@@ -31,7 +33,17 @@ function Card({ item, index, columnTitle }: Props) {
             className={`${styles.card} ${snapshot.isDragging ? styles.dragging : ''}`}
             onClick={openModal}
           >
-            <div>{item.title}</div>
+            {imageUrl && (
+              <div className={styles.imageWrapper}>
+                <Image
+                  src={imageUrl}
+                  alt="할일카드 첨부이미지"
+                  fill
+                  className={styles.image}
+                />
+              </div>
+            )}
+            <div className={styles.title}>{title}</div>
           </div>
         )}
       </Draggable>
@@ -39,10 +51,10 @@ function Card({ item, index, columnTitle }: Props) {
         <Modal
           isClosing={isClosing}
           onClose={closeModal}
-          title={item.title}
+          title={title}
           hasCloseButton={true}
           headerComponent={() => (
-            <HeaderMenu closeModal={closeModal} cardId={item.id} />
+            <HeaderMenu closeModal={closeModal} cardId={id} />
           )}
         >
           <CardInfo card={item} columnTitle={columnTitle} />

--- a/src/app/(with-header-sidebar)/dashboard/[id]/components/Card.tsx
+++ b/src/app/(with-header-sidebar)/dashboard/[id]/components/Card.tsx
@@ -36,39 +36,43 @@ function Card({ item, index, columnTitle }: Props) {
             className={`${styles.card} ${snapshot.isDragging ? styles.dragging : ''}`}
             onClick={openModal}
           >
-            {imageUrl && (
-              <div className={styles.imageWrapper}>
-                <Image
-                  src={imageUrl}
-                  alt="할일카드 첨부이미지"
-                  fill
-                  className={styles.image}
-                />
+            <div className={styles.cardContainer}>
+              <div className={styles.imageContainer}>
+                {imageUrl && (
+                  <div className={styles.imageWrapper}>
+                    <Image
+                      src={imageUrl}
+                      alt="할일카드 첨부이미지"
+                      fill
+                      className={styles.image}
+                    />
+                  </div>
+                )}
               </div>
-            )}
-            <div className={styles.cardInfo}>
-              <h3 className={styles.title}>{title}</h3>
-              <div className={styles.contentContainer}>
-                <div className={styles.tagContainer}>
-                  {tags.map((tag, index) => (
-                    <Tag key={index} name={tag} />
-                  ))}
-                </div>
-                <div className={styles.optionalInfo}>
-                  <div className={styles.dueDateWrapper}>
-                    {dueDate && (
-                      <>
-                        <CalendarIcon className={styles.icon} />
-                        <span className={styles.dueDate}>{dueDate}</span>
-                      </>
+              <div className={styles.cardInfo}>
+                <h3 className={styles.title}>{title}</h3>
+                <div className={styles.contentContainer}>
+                  <div className={styles.tagContainer}>
+                    {tags.map((tag, index) => (
+                      <Tag key={index} name={tag} />
+                    ))}
+                  </div>
+                  <div className={styles.optionalInfo}>
+                    <div className={styles.dueDateWrapper}>
+                      {dueDate && (
+                        <>
+                          <CalendarIcon className={styles.icon} />
+                          <span className={styles.dueDate}>{dueDate}</span>
+                        </>
+                      )}
+                    </div>
+                    {assignee && (
+                      <Avatar
+                        name={assignee.nickname}
+                        className={styles.avatar}
+                      />
                     )}
                   </div>
-                  {assignee && (
-                    <Avatar
-                      name={assignee.nickname}
-                      className={styles.avatar}
-                    />
-                  )}
                 </div>
               </div>
             </div>

--- a/src/components/TagsInput.tsx
+++ b/src/components/TagsInput.tsx
@@ -12,17 +12,28 @@ interface TagsInputProps {
 export default function TagsInput({ name, setValue }: TagsInputProps) {
   const [tags, setTags] = useState<string[]>([]);
 
-  const handleKeyUp = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    const { value } = e.currentTarget;
+
+    if (e.key === 'Enter' && e.nativeEvent.isComposing === false) {
       e.preventDefault();
       e.stopPropagation();
 
-      const { value } = e.currentTarget;
       e.currentTarget.value = '';
 
       if (tags.includes(value) || value.trim() === '') return;
       setTags([...tags, value]);
       setValue(name, [...tags, value]);
+    }
+
+    if (e.key === 'Backspace' && value === '') {
+      e.preventDefault();
+
+      if (tags.length > 0) {
+        const nextValue = tags.slice(0, -1);
+        setValue(name, nextValue);
+        setTags(nextValue);
+      }
     }
   };
 
@@ -46,7 +57,7 @@ export default function TagsInput({ name, setValue }: TagsInputProps) {
         ))}
         <input
           className={styles.input}
-          onKeyDown={handleKeyUp}
+          onKeyDown={handleKeyDown}
           placeholder="입력 후 Enter"
         />
       </div>

--- a/src/components/header/UserInfo.tsx
+++ b/src/components/header/UserInfo.tsx
@@ -2,10 +2,9 @@
 
 import type { User } from '@/types/user';
 import Image from 'next/image';
-import { useState, useEffect } from 'react';
-import styles from './UserInfo.module.css';
 import UserInfoSkeleton from './skeleton/UserInfoSkeleton';
 import Avatar from '../Avatar';
+import styles from './UserInfo.module.css';
 
 // TODO 로그인 로직 완료 후 user정보 가져오기
 const user: User = {


### PR DESCRIPTION
## 📌 Related Issue

> close #94 

## 📝 Description

- 대시보드 메인 카드 프리뷰 css추가

## 📸 Screenshot
<img width="575" alt="image" src="https://github.com/user-attachments/assets/ad8202b1-866a-458c-8bec-a0d9e29f990d">
<img width="795" alt="image" src="https://github.com/user-attachments/assets/b8f24ad4-c821-43df-9518-52322e8e6b10">
<img width="383" alt="image" src="https://github.com/user-attachments/assets/081198c7-aa64-471e-aa75-cf117666d8d6">


## 📢 Notes

- 태블릿 뷰는 디자인 갑자기 다른데 대시보드 자체가 반응형이 아니라서 일단 너비 박아놓고 상상코딩했습니다